### PR TITLE
Separate twitch logic from UI/app logic

### DIFF
--- a/Lingo/Form1.vb
+++ b/Lingo/Form1.vb
@@ -55,16 +55,38 @@ Public Class Form1
         AddHandler client.OnJoinedChannel, AddressOf OnJoinedChannel
         AddHandler client.OnMessageReceived, AddressOf OnMessageReceived
         AddHandler client.OnWhisperReceived, AddressOf OnWhisperReceived
-        AddHandler client.OnConnected, AddressOf Client_OnConnected
-        AddHandler client.OnDisconnected, AddressOf Client_OnDisconnected
-        AddHandler client.OnReconnected, AddressOf Client_OnReconnected
-        AddHandler client.OnLeftChannel, AddressOf Client_onLeftChannel
-        AddHandler client.OnError, AddressOf Client_onError
+        AddHandler client.OnConnected, AddressOf Twitch_Client_OnConnected
+        AddHandler client.OnDisconnected, AddressOf Twitch_OnDisconnected
+        AddHandler client.OnReconnected, AddressOf Twitch_OnReconnected
+        AddHandler client.OnLeftChannel, AddressOf Twitch_onLeftChannel
+        AddHandler client.OnError, AddressOf Twitch_onError
         Try
             client.Connect()
         Catch
             Me.Invoke(Sub() Me.TwitchConnectionFailed("Can't connect to Twitch.  Close and try again."))
         End Try
+    End Sub
+
+    Private Sub Twitch_onError(sender As Object, e As OnErrorEventArgs)
+        Debug.WriteLine(e.Exception.Message)
+    End Sub
+
+    Private Sub Twitch_onLeftChannel(sender As Object, e As OnLeftChannelArgs)
+        Me.Invoke(Sub() TwitchConnectionStatusChanged("Left Channel"))
+    End Sub
+
+    Private Sub Twitch_Client_OnConnected(ByVal sender As Object, ByVal e As OnConnectedArgs)
+        Debug.WriteLine($"Connected to {e.AutoJoinChannel}")
+        Me.Invoke(Sub() TwitchConnectionStatusChanged("Connected"))
+    End Sub
+
+    Private Sub Twitch_OnReconnected(ByVal sender As Object, ByVal e As OnReconnectedEventArgs)
+        Me.Invoke(Sub() TwitchConnectionStatusChanged("Reconnected"))
+    End Sub
+
+    Private Sub Twitch_OnDisconnected(ByVal sender As Object, ByVal e As OnDisconnectedEventArgs)
+        Me.Invoke(Sub() TwitchConnectionStatusChanged("Disconnected"))
+        Twitch_Connect(client.ConnectionCredentials.TwitchUsername, client.ConnectionCredentials.TwitchOAuth, client.JoinedChannels.First.Channel)
     End Sub
 
 
@@ -77,6 +99,15 @@ Public Class Form1
         MsgBox(reason)
         Me.Invoke(Sub() dumpdata())
         Me.Invoke(Sub() Me.Close())
+    End Sub
+
+    Private Sub TwitchConnectionStatusChanged(status As String)
+        Debug.WriteLine(status)
+        If status.ToLower.Contains("channel") Then
+            Me.Invoke(Sub() TextBox3.Text = status)
+        Else
+            Me.Invoke(Sub() TextBox2.Text = status)
+        End If
     End Sub
 
     Private Sub Form1_Load(sender As Object, e As EventArgs) Handles Me.Load
@@ -106,30 +137,6 @@ Public Class Form1
         PublicDisplay.Location = Screen.AllScreens(screennumber).Bounds.Location
         PublicDisplay.Size = Screen.AllScreens(screennumber).Bounds.Size
         PublicDisplay.Show()
-    End Sub
-
-    Private Sub Client_onError(sender As Object, e As OnErrorEventArgs)
-        Debug.WriteLine(e.Exception.Message)
-    End Sub
-
-    Private Sub Client_onLeftChannel(sender As Object, e As OnLeftChannelArgs)
-        Me.Invoke(Sub() TextBox3.Text = "Left Channel")
-    End Sub
-
-    Private Sub Client_OnConnected(ByVal sender As Object, ByVal e As OnConnectedArgs)
-        Debug.WriteLine($"Connected to {e.AutoJoinChannel}")
-        Me.Invoke(Sub() TextBox2.Text = "Connected")
-        Debug.WriteLine("Connected")
-    End Sub
-    Private Sub Client_OnReconnected(ByVal sender As Object, ByVal e As OnReconnectedEventArgs)
-        Me.Invoke(Sub() TextBox2.Text = "Reconnected")
-        Debug.WriteLine("Reconnected")
-    End Sub
-    Private Sub Client_OnDisconnected(ByVal sender As Object, ByVal e As OnDisconnectedEventArgs)
-        Me.Invoke(Sub() TextBox2.Text = "Disconnected")
-        Debug.WriteLine("Disconnected")
-
-        Twitch_Connect(client.ConnectionCredentials.TwitchUsername, client.ConnectionCredentials.TwitchOauth, client.JoinedChannels)
     End Sub
 
     Private Sub dumpdata()

--- a/Lingo/Form1.vb
+++ b/Lingo/Form1.vb
@@ -107,6 +107,14 @@ Public Class Form1
         Me.Invoke(Sub() Me.TwitchReceivedMessage(e.WhisperMessage.Message, e.WhisperMessage.Username, MessageModes.whisper))
     End Sub
 
+    Private Sub Twitch_SendMessageToUser(receiver As String, message As String)
+        client.SendWhisper(receiver, message)
+    End Sub
+
+    Private Sub Twitch_SendMessageToChannel(receiver As String, message As String)
+        client.SendMessage(receiver, message)
+    End Sub
+
 
 
     ' UI and application logic
@@ -267,12 +275,13 @@ Public Class Form1
         Dim match As Predicate(Of Player) = Function(pl) pl.Name = username
         If players.Exists(match) Then
             Dim p As Player = players.Find(match)
-            p.setfeedback(mode)
             Select Case mode
                 Case MessageModes.whisper
-                    client.SendWhisper(username, p.feedback)
+                    p.setfeedback(True)
+                    Twitch_SendMessageToUser(username, p.feedback)
                 Case MessageModes.chat
-                    client.SendMessage(channel, p.feedback)
+                    p.setfeedback(False)
+                    Twitch_SendMessageToChannel(channel, p.feedback)
             End Select
         End If
     End Sub

--- a/Lingo/Player.vb
+++ b/Lingo/Player.vb
@@ -106,43 +106,27 @@ Public Class Player
         End Using
         Me.graphic = b
     End Sub
-    Friend Sub setfeedback(ByVal mode As String)
-        Try
-            Select Case mode
-                Case "whisper"
-                    Dim outputstring As String = "Previous guesses: "
-                    For Each g As String In Me.allguesses
-                        If g <> "" Then
-                            Select Case Form1.wordlist.Contains(g.ToUpper())
-                                Case True
-                                    Dim temp As String = Form1.getLingoResult(Form1.Label4.Text, g)
-                                    temp = temp.Replace("!", "🔲")
-                                    temp = temp.Replace("?", "◯")
-                                    temp = temp.Replace("/", "☒")
-                                    outputstring += g.ToUpper + " - " + temp + "     "
-                                Case False
-                                    outputstring += g.ToUpper + " - " + "NOT A WORD" + "     "
-                            End Select
-                        End If
-                    Next
-                    Me.feedback = outputstring
-                Case "chat"
-                    Dim outputstring As String = Me.Name + ", " + "your last on-screen feedback was: "
-                    Dim g As String = Me.allguesses.Last
-                    Select Case Form1.wordlist.Contains(g.ToUpper())
-                        Case True
-                            Dim temp As String = Form1.getLingoResult(Form1.Label4.Text, g)
-                            temp = temp.Replace("!", "🔲")
-                            temp = temp.Replace("?", "◯")
-                            temp = temp.Replace("/", "☒")
-                            outputstring += temp
-                        Case False
-                            outputstring += "NOT A WORD"
-                    End Select
-                    Me.feedback = outputstring
-            End Select
-        Catch
-            'no feedback, most likely
-        End Try
+
+    Private Function FeedbackForGuess(guess As String)
+        If Form1.wordlist.Contains(guess.ToUpper) Then
+            Return Form1.getLingoResult(Form1.Label4.Text, guess).Replace("!", "🔲").Replace("?", "◯").Replace("/", "☒")
+        Else
+            Return "NOT A WORD"
+        End If
+    End Function
+
+    Friend Sub setfeedback(includeAllGuesses As Boolean)
+        Dim outputstring As String
+        If includeAllGuesses Then
+            outputstring = "Previous guesses: "
+            For Each guess As String In Me.allguesses
+                If guess <> "" Then
+                    outputstring += guess.ToUpper + " - " + FeedbackForGuess(guess) + "     "
+                End If
+            Next
+        Else
+            outputstring = Me.Name + ", " + "your last on-screen feedback was: " + FeedbackForGuess(Me.allguesses.Last)
+        End If
+        Me.feedback = outputstring
     End Sub
 End Class


### PR DESCRIPTION
This PR separates all the logic associated with managing the Twitch connection and responding to Twitch events from the UI/Application logic.  This is in preparation for adding similar logic for managing a Discord connection or other chat-type connections.

While there are a lot of changes in this PR, each commit deals with reasonably small changes, so it might be easier to look at the changes commit-by-commit rather than everything at once.  Do this by going to the "Commits" list and clicking on each commit title in turn to view the changes introduced by that commit (then use the "Back" button to return to the PR)

If you do look at the "changed files" view to see all the changes at once, here are the changes in the order they appear.

In `Form1.vb`:

1. New Enum `MessageModes` to indicate either `chat` or `whisper` for the source of a message (this replaces strings used in the existing logic)
2. New Sub `Twitch_Connect` that accepts a username, OAuth token, and channel name, and performs all the connection-related logic.  This same logic is then removed from `Form1_Load` and `Client_OnDisconnected`.
3. The Twitch event handlers are all renamed to begin with the `Twitch_` prefix.
4. A new callback `TwitchConnectionFailed` is called if an exception is raised in the Twitch `client.Connect()` call.
5. In the Twitch connection-related event handlers, the code to change the UI is moved into a new callback `TwitchConnectionStatusChanged`.
6. The `Twitch_OnJoinedChannel`  event handler now calls a new callback `ChangeGameModeTo` to change the game mode; other places in the code that change the game mode are similarly modified (to allow future logic changes to the game mode to happen in one place)
7. The `Twitch_OnMessageReceived` and `Twitch_OnWhisperReceived` now pass their message and sender information onto a new callback `TwitchReceivedMessage` which handles the message processing logic.
8. New `Twitch_SendMessageToUser` and `Twitch_SendMessageToChannel` subs are defined for sending messages.
9. The `sendfeedback` logic now uses the updated `Player.setfeedback` sub (described in the `Player.vb` section below) and the new `Tiwtch_SendMessageTo*` subs.

In `Player.vb`:

1. A new private `Player.FeedbackForGuess` function is created to return the feedback for a specific guess.
2. `Player.setfeedback` is changed to accept a boolean `includeAllGuesses` parameter, rather than deciding the logic based on a mode string; it also now uses the `FeedbackForGuess` function to format the feedback.	