### PR TITLE
Move twitch logic to its own class and file

### DIFF
--- a/Lingo/App.config
+++ b/Lingo/App.config
@@ -34,8 +34,11 @@
       <setting name="twitch_username" serializeAs="String">
         <value />
       </setting>
-      <setting name="twitch_oauth" serializeAs="String">
+      <setting name="twitch_oauth_token" serializeAs="String">
         <value />
+      </setting>
+      <setting name="twitch_bot_owner" serializeAs="String">
+        <value>Liquid_Kourage</value>
       </setting>
     </Lingo.My.MySettings>
   </userSettings>

--- a/Lingo/Form1.vb
+++ b/Lingo/Form1.vb
@@ -1,11 +1,4 @@
-﻿Imports TwitchLib.Client
-Imports TwitchLib.Client.Enums
-Imports TwitchLib.Client.Events
-Imports TwitchLib.Client.Extensions
-Imports TwitchLib.Client.Models
-Imports TwitchLib.Communication.Events
-Imports TwitchLib.Api
-Imports System.Drawing.Drawing2D
+﻿Imports System.Drawing.Drawing2D
 Imports Microsoft.VisualBasic.FileIO
 Imports System.Text
 Imports System.Timers
@@ -16,9 +9,10 @@ Imports System.ComponentModel
 
 Public Class Form1
     Public g As Graphics
-    Public client As TwitchClient
+    Public WithEvents ChatBot As IChatBot
+    Public Channel As IChatBot.IChannel = Nothing
     Public wordlist1, wordlist2 As List(Of String)
-    Public gamemode As GameModes
+    Public gamemode As GameModes = GameModes.notready
     Dim gametimer As Timer
     Dim gametime As Integer
     Dim scoringcompleted As Boolean
@@ -39,94 +33,76 @@ Public Class Form1
         guessing
         waiting
         results
+        notready = -1
     End Enum
-
-
-
-    ' Twitch connection logic
-
-
 
     Enum MessageModes
         chat
         whisper
     End Enum
 
-    Private Sub Twitch_Connect(botUsername As String, botOauth As String, channel As String)
-        Dim credentials As New ConnectionCredentials(botUsername, botOauth)
-        client = New TwitchClient()
-        client.Initialize(credentials, channel)
-        AddHandler client.OnJoinedChannel, AddressOf Twitch_OnJoinedChannel
-        AddHandler client.OnMessageReceived, AddressOf Twitch_OnMessageReceived
-        AddHandler client.OnWhisperReceived, AddressOf Twitch_OnWhisperReceived
-        AddHandler client.OnConnected, AddressOf Twitch_Client_OnConnected
-        AddHandler client.OnDisconnected, AddressOf Twitch_OnDisconnected
-        AddHandler client.OnReconnected, AddressOf Twitch_OnReconnected
-        AddHandler client.OnLeftChannel, AddressOf Twitch_onLeftChannel
-        AddHandler client.OnError, AddressOf Twitch_onError
-        Try
-            client.Connect()
-        Catch
-            Me.Invoke(Sub() Me.TwitchConnectionFailed("Can't connect to Twitch.  Close and try again."))
-        End Try
+
+
+
+    ' ChatBot event handlers
+
+
+
+    Private Sub ChatBot_Ready() Handles ChatBot.Ready
+        ' Only do the initial steps if we haven't done anything yet
+        If gamemode = GameModes.notready Then
+            Channel.SendMessage("Lingo is LIVE!  To sign up: Using either the Twitch chat or a whisper to KourageTheCowardlyBot, type the word '!in'!")
+            ChangeGameModeTo(GameModes.registration)
+        End If
     End Sub
 
-    Private Sub Twitch_onError(sender As Object, e As OnErrorEventArgs)
-        Debug.WriteLine(e.Exception.Message)
+    Private Sub ChatBot_ConnectedToServer() Handles ChatBot.ConnectedToServer
+        ConnectionStatusChanged("Connected")
     End Sub
 
-    Private Sub Twitch_onLeftChannel(sender As Object, e As OnLeftChannelArgs)
-        Me.Invoke(Sub() TwitchConnectionStatusChanged("Left Channel"))
+    Private Sub ChatBot_ReconnectedToServer() Handles ChatBot.ReconnectedToServer
+        ConnectionStatusChanged("Reconnected")
     End Sub
 
-    Private Sub Twitch_Client_OnConnected(ByVal sender As Object, ByVal e As OnConnectedArgs)
-        Debug.WriteLine($"Connected to {e.AutoJoinChannel}")
-        Me.Invoke(Sub() TwitchConnectionStatusChanged("Connected"))
+    Private Sub ChatBot_DisconnectedFromServer() Handles ChatBot.DisconnectedFromServer
+        ConnectionStatusChanged("Disconnected")
     End Sub
 
-    Private Sub Twitch_OnReconnected(ByVal sender As Object, ByVal e As OnReconnectedEventArgs)
-        Me.Invoke(Sub() TwitchConnectionStatusChanged("Reconnected"))
+    Private Sub ChatBot_JoinedChannel(Channel As IChatBot.IChannel) Handles ChatBot.JoinedChannel
+        If Me.Channel Is Nothing Then
+            Me.Channel = Channel
+        End If
+        ConnectionStatusChanged("Joined Channel")
     End Sub
 
-    Private Sub Twitch_OnDisconnected(ByVal sender As Object, ByVal e As OnDisconnectedEventArgs)
-        Me.Invoke(Sub() TwitchConnectionStatusChanged("Disconnected"))
-        Twitch_Connect(client.ConnectionCredentials.TwitchUsername, client.ConnectionCredentials.TwitchOAuth, client.JoinedChannels.First.Channel)
+    Private Sub ChatBot_MessageReceived(Message As String, Source As IChatBot.IUser, Channel As IChatBot.IChannel) Handles ChatBot.MessageReceived
+        Handle_ChatBot_Message(Message, Source, MessageModes.chat)
     End Sub
 
-    Private Sub Twitch_OnJoinedChannel(ByVal sender As Object, ByVal e As OnJoinedChannelArgs)
-        client.SendMessage(e.Channel, "Lingo is LIVE!  To sign up: Using either the Twitch chat or a whisper to KourageTheCowardlyBot, type the word '!in'!")
-        ChangeGameModeTo(GameModes.registration, New GameModes() {Nothing})
+    Private Sub ChatBot_PrivateMessageReceived(Message As String, Source As IChatBot.IUser) Handles ChatBot.PrivateMessageReceived
+        Handle_ChatBot_Message(Message, Source, MessageModes.whisper)
     End Sub
 
-    Private Sub Twitch_OnMessageReceived(ByVal sender As Object, ByVal e As OnMessageReceivedArgs)
-        Me.Invoke(Sub() Me.TwitchReceivedMessage(e.ChatMessage.Message, e.ChatMessage.Username, MessageModes.chat))
+    Private Sub ChatBot_LeftChannel(Channel As IChatBot.IChannel) Handles ChatBot.LeftChannel
+        ConnectionStatusChanged("Left Channel")
+        If Channel.ChannelId = Me.Channel.ChannelId Then
+            Me.Channel = Nothing
+        End If
     End Sub
 
-    Private Sub Twitch_OnWhisperReceived(ByVal sender As Object, ByVal e As OnWhisperReceivedArgs)
-        Me.Invoke(Sub() Me.TwitchReceivedMessage(e.WhisperMessage.Message, e.WhisperMessage.Username, MessageModes.whisper))
-    End Sub
-
-    Private Sub Twitch_SendMessageToUser(receiver As String, message As String)
-        client.SendWhisper(receiver, message)
-    End Sub
-
-    Private Sub Twitch_SendMessageToChannel(receiver As String, message As String)
-        client.SendMessage(receiver, message)
-    End Sub
-
-
-
-    ' UI and application logic
-
-
-
-    Private Sub TwitchConnectionFailed(reason As String)
-        MsgBox(reason)
+    Private Sub ChatBot_ConnectionFailed(Reason As String) Handles ChatBot.ConnectionFailed
+        Me.Invoke(Sub() MsgBox(Reason))
         Me.Invoke(Sub() dumpdata())
         Me.Invoke(Sub() Me.Close())
     End Sub
 
-    Private Sub TwitchConnectionStatusChanged(status As String)
+
+
+    ' Game logic
+
+
+
+    Private Sub ConnectionStatusChanged(status As String)
         Debug.WriteLine(status)
         If status.ToLower.Contains("channel") Then
             Me.Invoke(Sub() TextBox3.Text = status)
@@ -135,19 +111,19 @@ Public Class Form1
         End If
     End Sub
 
-    Private Sub TwitchReceivedMessage(message As String, fromUser As String, Optional howReceived As MessageModes = MessageModes.chat)
+    Private Sub Handle_ChatBot_Message(message As String, fromUser As IChatBot.IUser, Optional howReceived As MessageModes = MessageModes.chat)
         Select Case True
             Case message.ToLower = "!in"
                 'client.SendWhisper(e.WhisperMessage.Username, "Your entry is confirmed.")
-                Me.Invoke(Sub() registerplayer(fromUser))
+                Me.Invoke(Sub() registerplayer(fromUser.UserName))
             Case message.ToLower = "!out"
-                Me.Invoke(Sub() unregisterplayer(fromUser))
+                Me.Invoke(Sub() unregisterplayer(fromUser.UserName))
             Case message.ToLower = "!feedback"
-                Me.Invoke(Sub() sendfeedback(fromUser, client, howReceived))
+                Me.Invoke(Sub() sendfeedback(fromUser, howReceived))
             Case gamemode = GameModes.guessing And howReceived = MessageModes.whisper
                 If System.Text.RegularExpressions.Regex.IsMatch(message, "^[A-Za-z]{5}$") Then
-                    Me.Invoke(Sub() updateplayerguess(fromUser, message))
-                    Me.Invoke(Sub() lockinplayerguess(fromUser))
+                    Me.Invoke(Sub() updateplayerguess(fromUser.UserName, message))
+                    Me.Invoke(Sub() lockinplayerguess(fromUser.UserName))
                     Dim stillwaiting As Boolean = False
                     For Each p As Player In players
                         'need to limit this to players who have not already gotten the word right
@@ -155,7 +131,7 @@ Public Class Form1
                     Next
                     If Not stillwaiting Then Me.Invoke(Sub() Button1.PerformClick())
                 Else
-                    Me.Invoke(Sub() updateplayernotes(fromUser, message))
+                    Me.Invoke(Sub() updateplayernotes(fromUser.UserName, message))
                 End If
                 'Case gamemode = GameModes.results
                 '    Dim match As Predicate(Of Player) = Function(pl) pl.Name = e.WhisperMessage.Username
@@ -182,7 +158,7 @@ Public Class Form1
                 '        End If
                 '    End If
             Case howReceived = MessageModes.whisper
-                Me.Invoke(Sub() updateplayernotes(fromUser, message))
+                Me.Invoke(Sub() updateplayernotes(fromUser.UserName, message))
         End Select
     End Sub
 
@@ -202,6 +178,89 @@ Public Class Form1
         End If
     End Sub
 
+    Private Sub dumpdata()
+        Dim formatter As IFormatter = New BinaryFormatter()
+        Dim stream As Stream = New FileStream("lingosave.bin", FileMode.Create, FileAccess.Write, FileShare.None)
+        formatter.Serialize(stream, players)
+        stream.Close()
+    End Sub
+
+    Private Sub registerplayer(username As String)
+        Dim p As Player = players.Find(Function(pl As Player) pl.Name = username)
+        If p Is Nothing Then
+            p = New Player(username)
+            players.Add(p)
+            players.Sort(Function(x, y) x.Name.CompareTo(y.Name))
+            AddPlayerToUI(p)
+        End If
+    End Sub
+
+    Private Sub unregisterplayer(username As String)
+        Dim p As Player = players.Find(Function(pl As Player) pl.Name = username)
+        If p IsNot Nothing Then
+            RemovePlayerFromUI(p)
+            players.Remove(p)
+        End If
+    End Sub
+
+    Private Sub updatescore(username As String, score As Integer)
+        Dim p As Player = players.Find(Function(pl As Player) pl.Name = username)
+        If p IsNot Nothing Then
+            p.Balls = score
+            p.updategraphic()
+            drawuserresult(p)
+        End If
+    End Sub
+
+    Private Sub sendfeedback(user As IChatBot.IUser, mode As MessageModes)
+        Dim p As Player = players.Find(Function(pl As Player) pl.Name = user.UserName)
+        If p IsNot Nothing Then
+            Select Case mode
+                Case MessageModes.whisper
+                    p.setfeedback(True)
+                    user.SendMessage(p.feedback)
+                Case MessageModes.chat
+                    p.setfeedback(False)
+                    Channel.SendMessage(p.feedback)
+            End Select
+        End If
+    End Sub
+
+    Private Sub lockinplayerguess(username As String)
+        Dim p As Player = players.Find(Function(pl As Player) pl.Name = username)
+        If p IsNot Nothing Then
+            p.updategraphic("     ", True)
+            drawuserresult(p)
+        End If
+    End Sub
+
+    Private Sub updateplayerguess(username As String, message As String)
+        Dim p As Player = players.Find(Function(pl As Player) pl.Name = username)
+        If p IsNot Nothing Then
+            p.guess = message
+            UpdatePlayerGuessInUI(p)
+        End If
+    End Sub
+
+    Private Sub updateplayernotes(username As String, message As String)
+        Dim p As Player = players.Find(Function(pl As Player) pl.Name = username)
+        If p IsNot Nothing Then
+            p.notes.Add(message)
+            For i As Integer = 0 To ListBox3.Items.Count - 1
+                If ListBox3.Items(i).StartsWith(username + " - ") Then
+                    ListBox3.Items(i) = username + " - " + message
+                    Exit For
+                End If
+            Next
+            p.hasnotes = True
+        End If
+    End Sub
+
+
+
+
+    ' UI Logic
+
     Private Sub Form1_Load(sender As Object, e As EventArgs) Handles Me.Load
         If My.Settings.twitch_channel = "" Then
             My.Settings.twitch_channel = InputBox("What is the name of your Twitch channel?  Omit the 'twitch.tv/' part.")
@@ -211,8 +270,8 @@ Public Class Form1
             My.Settings.twitch_username = InputBox("What Twitch username should I log in to?")
         End If
 
-        If My.Settings.twitch_oauth = "" Then
-            My.Settings.twitch_bot_oath = InputBox("What Twitch OAuth Token should I use to log in?")
+        If My.Settings.twitch_oauth_token = "" Then
+            My.Settings.twitch_oauth_token = InputBox("What Twitch OAuth Token should I use to log in?")
         End If
 
         gametimer = New Timer(1000)
@@ -224,7 +283,7 @@ Public Class Form1
         Next
 
         ' Twitch_Connect("kouragethecowardlybot", "mui2jnpzbi4ne7uohndwz5j0scbpym", channel)
-        Twitch_Connect(My.Settings.twitch_username, My.Settings.twitch_oauth, My.Settings.twitch_channel)
+        ChatBot = New TwitchBot(My.Settings.twitch_username, My.Settings.twitch_oauth_token, My.Settings.twitch_channel, My.Settings.twitch_bot_owner)
 
         Dim screennumber As Integer = 0
         If My.Settings.screennumber = -1 Then
@@ -238,96 +297,25 @@ Public Class Form1
         PublicDisplay.Show()
     End Sub
 
-    Private Sub dumpdata()
-        Dim formatter As IFormatter = New BinaryFormatter()
-        Dim stream As Stream = New FileStream("lingosave.bin", FileMode.Create, FileAccess.Write, FileShare.None)
-        formatter.Serialize(stream, players)
-        stream.Close()
-    End Sub
-
-    Private Sub registerplayer(username As String)
-        Dim match As Predicate(Of Player) = Function(pl) pl.Name = username
-        If players.Exists(match) Then Exit Sub
-        Dim p As New Player(username)
-        players.Add(p)
-        players.Sort(Function(x, y) x.Name.CompareTo(y.Name))
+    Private Sub AddPlayerToUI(p As Player)
         drawalluserresults()
-        ListBox2.Items.Add(username + " - ")
-        ListBox3.Items.Add(username + " - ")
+        ListBox2.Items.Add(p.Name + " - ")
+        ListBox3.Items.Add(p.Name + " - ")
     End Sub
 
-    Private Sub unregisterplayer(username As String)
-        Dim match As Predicate(Of Player) = Function(pl) pl.Name = username
-        If players.Exists(match) Then
-            Dim p As Player = players.Find(match)
-            players.Remove(p)
-        End If
+    Private Sub RemovePlayerFromUI(p As Player)
         drawalluserresults()
-        ListBox2.Items.Remove(username + " - ")
-        ListBox3.Items.Remove(username + " - ")
+        ListBox2.Items.Remove(p.Name + " - ")
+        ListBox3.Items.Remove(p.Name + " - ")
     End Sub
 
-    Private Sub updatescore(username As String, score As Integer)
-        Dim match As Predicate(Of Player) = Function(pl) pl.Name = username
-        If players.Exists(match) Then
-            Dim p As Player = players.Find(match)
-            p.Balls = score
-            p.updategraphic()
-            drawuserresult(p)
-        End If
-    End Sub
-
-    Private Sub sendfeedback(username As String, client As TwitchClient, mode As MessageModes)
-        Dim match As Predicate(Of Player) = Function(pl) pl.Name = username
-        If players.Exists(match) Then
-            Dim p As Player = players.Find(match)
-            Select Case mode
-                Case MessageModes.whisper
-                    p.setfeedback(True)
-                    Twitch_SendMessageToUser(username, p.feedback)
-                Case MessageModes.chat
-                    p.setfeedback(False)
-                    Twitch_SendMessageToChannel(My.Settings.twitch_channel, p.feedback)
-            End Select
-        End If
-    End Sub
-
-    Private Sub lockinplayerguess(username As String)
-        Dim match As Predicate(Of Player) = Function(pl) pl.Name = username
-        If players.Exists(match) Then
-            Dim p As Player = players.Find(match)
-            p.updategraphic("     ", True)
-            drawuserresult(p)
-        End If
-    End Sub
-
-    Private Sub updateplayerguess(username As String, message As String)
-        Dim match As Predicate(Of Player) = Function(pl) pl.Name = username
-        If players.Exists(match) Then
-            Dim p As Player = players.Find(match)
-            p.guess = message
-            For i As Integer = 0 To ListBox2.Items.Count - 1
-                If ListBox2.Items(i).StartsWith(username + " - ") Then
-                    ListBox2.Items(i) = username + " - " + message.ToUpper
-                    Exit For
-                End If
-            Next
-        End If
-    End Sub
-
-    Private Sub updateplayernotes(username As String, message As String)
-        Dim match As Predicate(Of Player) = Function(pl) pl.Name = username
-        If players.Exists(match) Then
-            Dim p As Player = players.Find(match)
-            p.notes.Add(message)
-            For i As Integer = 0 To ListBox3.Items.Count - 1
-                If ListBox3.Items(i).StartsWith(username + " - ") Then
-                    ListBox3.Items(i) = username + " - " + message
-                    Exit For
-                End If
-            Next
-            p.hasnotes = True
-        End If
+    Private Sub UpdatePlayerGuessInUI(p As Player)
+        For i As Integer = 0 To ListBox2.Items.Count - 1
+            If ListBox2.Items(i).StartsWith(p.Name + " - ") Then
+                ListBox2.Items(i) = p.Name + " - " + p.guess.ToUpper
+                Exit For
+            End If
+        Next
     End Sub
 
     Private Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click
@@ -347,11 +335,7 @@ Public Class Form1
         If numballs = 6 * ballmultiplier Then numballs = 5 * ballmultiplier
         If beenguessed Then numballs -= 1 * ballmultiplier
         If numballs >= 2 * ballmultiplier Then
-            While client.JoinedChannels.Count = 0
-                client.Connect()
-                Threading.Thread.Sleep(5000)
-            End While
-            Me.Invoke(Sub() client.SendMessage(client.JoinedChannels(0), "Time's up!  You now have 45 seconds to look at your feedback.  To see this at any time, type !feedback in chat."))
+            Channel.SendMessage("Time's up!  You now have 45 seconds to look at your feedback.  To see this at any time, type !feedback in chat.")
             gametime = 45
             gametimer.Start()
         Else
@@ -442,11 +426,11 @@ Public Class Form1
         For i As Integer = 0 To ListBox2.Items.Count - 1
             ListBox2.Items(i) = ListBox2.Items(i).ToString.Split(" - ")(0) + " - "
         Next
-        While client.JoinedChannels.Count = 0
-            client.Connect()
+        While Me.Channel Is Nothing
+            ChatBot.Reconnect()
             Threading.Thread.Sleep(5000)
         End While
-        Me.Invoke(Sub() client.SendMessage(client.JoinedChannels(0), "Round " + roundnum.ToString + " has started!  The first letter is " + Label4.Text.Chars(0) + ".  You have 90 seconds to submit your guess via whisper!"))
+        Channel.SendMessage($"Round {roundnum} has started!  The first letter is {Label4.Text.Chars(0)}.  You have 90 seconds to submit your guess via whisper!")
         gametime = 90
         gametimer.Start()
     End Sub
@@ -461,11 +445,11 @@ Public Class Form1
         For i As Integer = 0 To ListBox2.Items.Count - 1
             ListBox2.Items(i) = ListBox2.Items(i).ToString.Split(" - ")(0) + " - "
         Next
-        While client.JoinedChannels.Count = 0
-            client.Connect()
+        While Me.Channel Is Nothing
+            ChatBot.Reconnect()
             Threading.Thread.Sleep(5000)
         End While
-        Me.Invoke(Sub() client.SendMessage(client.JoinedChannels(0), "Round " + roundnum.ToString + " continues for " + numballs.ToString + " balls!  The first letter is " + Label4.Text.Chars(0) + ".  You have 90 seconds to submit your guess via whisper!"))
+        Channel.SendMessage($"Round {roundnum} continues for {numballs} balls!  The first letter is `{Label4.Text.Chars(0)}`.  You have 90 seconds to submit your guess via whisper!")
         gametime = 90
         gametimer.Start()
     End Sub
@@ -474,9 +458,13 @@ Public Class Form1
         gametime -= 1
         Select Case True
             Case gametime = 30 AndAlso gamemode = GameModes.guessing
-                If Not (client.JoinedChannels.Count = 0) Then client.SendMessage(client.JoinedChannels(0), "30 seconds to go...")
+                If Channel IsNot Nothing Then
+                    Channel.SendMessage("30 seconds to go...")
+                End If
             Case gametime = 10 AndAlso gamemode = GameModes.guessing
-                If Not (client.JoinedChannels.Count = 0) Then client.SendMessage(client.JoinedChannels(0), "LAST CHANCE, 10 seconds...")
+                If Channel IsNot Nothing Then
+                    Channel.SendMessage("LAST CHANCE, 10 seconds...")
+                End If
                 'Case gametime = 100
                 'client.SendMessage(client.JoinedChannels(0), "10 seconds left...")
                 'Case gametime = 50
@@ -645,7 +633,7 @@ Public Class Form1
         If MsgBox("This mode cannot be disabled.  Are you sure?", MsgBoxStyle.YesNo, "Enable 2x Ball Mode") = 7 Then Exit Sub
         ballmultiplier = 2
         Button9.Enabled = False
-        Me.Invoke(Sub() client.SendMessage(client.JoinedChannels(0), "Hold your hats everyone, now we're playing for DOUBLE BALLS!"))
+        Channel.SendMessage("Hold your hats everyone, now we're playing for DOUBLE BALLS!")
     End Sub
 
     Private Sub TextBox1_KeyDown(sender As Object, e As KeyEventArgs) Handles TextBox1.KeyDown

--- a/Lingo/IChatBot.vb
+++ b/Lingo/IChatBot.vb
@@ -1,0 +1,124 @@
+﻿''' <summary>
+''' A generic "chat bot" interface.
+''' </summary>
+''' <remarks>
+''' Written by Johnson Earls.
+''' For support, email me at darkfoxprime@gmail.com.
+''' </remarks>
+Public Interface IChatBot
+
+    ''' <summary>
+    ''' A "generic" representation of a chat channel.  Every channel must have some sort of unique ID, a visible name, and a way to send a message to that channel.
+    ''' </summary>
+    Interface IChannel
+        ''' <summary>
+        ''' The unique ID for the channel.
+        ''' </summary>
+        ReadOnly Property ChannelId As Object
+        ''' <summary>
+        ''' The visible name for the channel.
+        ''' </summary>
+        ReadOnly Property ChannelName As String
+        ''' <summary>
+        ''' Send a message to this channel.
+        ''' </summary>
+        ''' <param name="Message">The text of the message to send</param>
+        Sub SendMessage(Message As String)
+    End Interface
+
+    ''' <summary>
+    ''' A "generic" representation of a chat user.  Every user must have some sort of unique ID, a visible name, and a way to send a message to that user.
+    ''' </summary>
+    Interface IUser
+        ''' <summary>
+        ''' The unique ID for the user.
+        ''' </summary>
+        ReadOnly Property UserId As Object
+        ''' <summary>
+        ''' The visible name for the user.
+        ''' </summary>
+        ReadOnly Property UserName As String
+        ''' <summary>
+        ''' Send a message to this user.
+        ''' </summary>
+        ''' <param name="Message">The text of the message to send</param>
+        Sub SendMessage(Message As String)
+    End Interface
+
+    ''' <summary>
+    ''' Raised when the connection attempt fails for whatever reason.
+    ''' </summary>
+    ''' <param name="Reason">The error message from the failed connection attempt.</param>
+    Event ConnectionFailed(Reason As String)
+    ''' <summary>
+    ''' Raised when the bot connects to the server.
+    ''' </summary>
+    Event ConnectedToServer()
+    ''' <summary>
+    ''' Raised when the bot reconnects to the server.
+    ''' </summary>
+    Event ReconnectedToServer()
+    ''' <summary>
+    ''' Raised when the bot's connection is closed.
+    ''' </summary>
+    Event DisconnectedFromServer()
+    ''' <summary>
+    ''' Raised when the bot joins a channel.
+    ''' </summary>
+    ''' <param name="Channel">The <see cref="IChannel"</see> representing the channel that was joined.</param>
+    Event JoinedChannel(Channel As IChannel)
+    ''' <summary>
+    ''' Raised when the bot leaves a channel.
+    ''' </summary>
+    ''' <param name="Channel">The <see cref="IChannel"</see> representing the channel that was left.</param>
+    Event LeftChannel(Channel As IChannel)
+    ''' <summary>
+    ''' Raised when the bot is ready (meaning the client has connected and the bot has joined its channel).
+    ''' </summary>
+    Event Ready()
+    ''' <summary>
+    ''' Raised when a chat message is received in a channel.
+    ''' </summary>
+    ''' <param name="Message">The message text received.</param>
+    ''' <param name="Source">The <see cref="IUser"/> representation of the user who sent the message.</param>
+    ''' <param name="Channel">The <see cref="IChannel"/> representaiton of the channel in which the message was received.</param>
+    Event MessageReceived(Message As String, Source As IUser, Channel As IChannel)
+    ''' <summary>
+    ''' Raised when a private message is received from a user.
+    ''' </summary>
+    ''' <param name="Message">The message text received.</param>
+    ''' <param name="Source">The <see cref="IUser"/> representation of the user who sent the message.</param>
+    Event PrivateMessageReceived(Message As String, Source As IUser)
+
+    ''' <summary>
+    ''' Find a chat channel and return its <see cref="IChannel"/> representation.
+    ''' </summary>
+    ''' <param name="ChannelName">The name of the channel to find.</param>
+    ''' <returns>The <see cref="IChannel"/> representation of the channel.</returns>
+    Function FindChannel(ChannelName As String) As IChannel
+
+    ''' <summary>
+    ''' Find a user and return their <see cref="IUser"/> representation.
+    ''' </summary>
+    ''' <param name="UserName">The name of the user to find.</param>
+    ''' <returns>The <see cref="User"/> representation of the user.</returns>
+    Function FindUser(UserName As String) As IUser
+
+    ''' <summary>
+    ''' Return the bot's owner.
+    ''' </summary>
+    ''' <returns>The <see cref="IUser"/> representation of the bot's owner.</returns>
+    Function BotOwner() As IUser
+
+    ''' <summary>
+    ''' Close the bot's connection to the server.
+    ''' </summary>
+    Sub Close()
+
+    ''' <summary>
+    ''' Attempt to re-establish the bot's connection to the server,
+    ''' whether it's currently open or not.
+    ''' </summary>
+    Sub Reconnect()
+
+End Interface

--- a/Lingo/Lingo.vbproj
+++ b/Lingo/Lingo.vbproj
@@ -192,6 +192,7 @@
     <Import Include="System.Threading.Tasks" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IChatBot.vb" />
     <Compile Include="Form1.vb">
       <SubType>Form</SubType>
     </Compile>

--- a/Lingo/Lingo.vbproj
+++ b/Lingo/Lingo.vbproj
@@ -193,6 +193,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IChatBot.vb" />
+    <Compile Include="TwitchBot.vb" />
     <Compile Include="Form1.vb">
       <SubType>Form</SubType>
     </Compile>

--- a/Lingo/My Project/Settings.Designer.vb
+++ b/Lingo/My Project/Settings.Designer.vb
@@ -15,7 +15,7 @@ Option Explicit On
 Namespace My
     
     <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0"),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0"),  _
      Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
@@ -105,12 +105,24 @@ Namespace My
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("")>  _
-        Public Property twitch_oauth() As String
+        Public Property twitch_oauth_token() As String
             Get
-                Return CType(Me("twitch_oauth"),String)
+                Return CType(Me("twitch_oauth_token"),String)
             End Get
             Set
-                Me("twitch_oauth") = value
+                Me("twitch_oauth_token") = value
+            End Set
+        End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("Liquid_Kourage")>  _
+        Public Property twitch_bot_owner() As String
+            Get
+                Return CType(Me("twitch_bot_owner"),String)
+            End Get
+            Set
+                Me("twitch_bot_owner") = value
             End Set
         End Property
     End Class

--- a/Lingo/My Project/Settings.settings
+++ b/Lingo/My Project/Settings.settings
@@ -14,8 +14,11 @@
     <Setting Name="twitch_username" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="twitch_oauth" Type="System.String" Scope="User">
+    <Setting Name="twitch_oauth_token" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="twitch_bot_owner" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Liquid_Kourage</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/Lingo/TwitchBot.vb
+++ b/Lingo/TwitchBot.vb
@@ -1,0 +1,374 @@
+﻿Imports TwitchLib.Client
+Imports TwitchLib.Client.Enums
+Imports TwitchLib.Client.Events
+Imports TwitchLib.Client.Extensions
+Imports TwitchLib.Client.Models
+Imports TwitchLib.Communication.Events
+Imports TwitchLib.Api
+
+
+Public Class TwitchBot
+    Implements IChatBot
+
+    ' Class-specific types
+
+    ''' <summary>
+    ''' A simple enum used to choose between a private whisper or channel chat message
+    ''' </summary>
+    Public Enum MessageModes
+        chat
+        whisper
+    End Enum
+
+    ''' <summary>
+    ''' A "generic" representation of a chat user.  Every user must have some sort of unique ID, a visible name, and a way to send a message to that user.
+    ''' </summary>
+    ''' <seealso cref="IChatBot.IUser"/>
+    Public Class User
+        Implements IChatBot.IUser
+
+        ''' <summary>
+        ''' The unique ID (in this case, the user name itself) for the user.
+        ''' </summary>
+        ''' <seealso cref="IChatBot.IUser.UserId"/>
+        Public ReadOnly Property UserId As Object Implements IChatBot.IUser.UserId
+            Get
+                Return _UserName
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Backing store for <see cref="UserName"/>
+        ''' </summary>
+        Private _UserName As String
+
+        ''' <summary>
+        ''' The unique ID (in this case, the "room ID") for the user.
+        ''' </summary>
+        ''' <seealso cref="IChatBot.IUser.UserName"/>
+        Public ReadOnly Property UserName As String Implements IChatBot.IUser.UserName
+            Get
+                Return _UserName
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' The TwitchBot which holds the client used to talk to the user.
+        ''' </summary>
+        Private _TwitchBot As TwitchBot
+
+        ''' <summary>
+        ''' Send a message to this user.
+        ''' </summary>
+        ''' <param name="Message">The text of the message to send</param>
+        ''' <seealso cref="IChatBot.IUser.SendMessage"/>
+        Public Sub SendMessage(Message As String) Implements IChatBot.IUser.SendMessage
+            _TwitchBot.Client.SendWhisper(_UserName, Message)
+        End Sub
+
+        ''' <summary>
+        ''' Create the user representation.
+        ''' </summary>
+        ''' <param name="Name">The name of the user.</param>
+        ''' <param name="Bot">The TwitchBot which holds the client used to talk to the user.</param>
+        Public Sub New(Name As String, Bot As TwitchBot)
+            _UserName = Name
+            _TwitchBot = Bot
+        End Sub
+    End Class
+
+    ''' <summary>
+    ''' A "generic" representation of a chat channel.  Every channel must have some sort of unique ID, a visible name, and a way to send a message to that channel.
+    ''' </summary>
+    ''' <seealso cref="IChatBot.IChannel"/>
+    Public Class Channel
+        Implements IChatBot.IChannel
+
+        ''' <summary>
+        ''' The unique ID (in this case, the channel name itself) for the channel.
+        ''' </summary>
+        ''' <seealso cref="IChatBot.IChannel.ChannelId"/>
+        Public ReadOnly Property ChannelId As Object Implements IChatBot.IChannel.ChannelId
+            Get
+                Return _ChannelName
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Backing store for <see cref="ChannelName"/>
+        ''' </summary>
+        Private _ChannelName As String
+
+        ''' <summary>
+        ''' The unique ID (in this case, the "room ID") for the channel.
+        ''' </summary>
+        ''' <seealso cref="IChatBot.IChannel.ChannelName"/>
+        Public ReadOnly Property ChannelName As String Implements IChatBot.IChannel.ChannelName
+            Get
+                Return _ChannelName
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' The TwitchBot which holds the client used to talk to the channel.
+        ''' </summary>
+        Private _TwitchBot As TwitchBot
+
+        ''' <summary>
+        ''' Send a message to this channel.
+        ''' </summary>
+        ''' <param name="Message">The text of the message to send</param>
+        ''' <seealso cref="IChatBot.IChannel.SendMessage"/>
+        Public Sub SendMessage(Message As String) Implements IChatBot.IChannel.SendMessage
+            _TwitchBot.Client.SendMessage(_ChannelName, Message)
+        End Sub
+
+        ''' <summary>
+        ''' Create the channel representation.
+        ''' </summary>
+        ''' <param name="Name">The name of the channel.</param>
+        ''' <param name="Bot">The TwitchBot which holds the client used to talk to the channel.</param>
+        Public Sub New(Name As String, Bot As TwitchBot)
+            _ChannelName = Name
+            _TwitchBot = Bot
+        End Sub
+    End Class
+
+
+
+    ' Events raised by this class
+
+    ''' <seealso cref="IChatBot.ConnectionFailed"/>
+    Public Event ConnectionFailed(Reason As String) Implements IChatBot.ConnectionFailed
+    ''' <seealso cref="IChatBot.ConnectedToServer"/>
+    Public Event ConnectedToServer() Implements IChatBot.ConnectedToServer
+    ''' <seealso cref="IChatBot.ReconnectedToServer"/>
+    Public Event ReconnectedToServer() Implements IChatBot.ReconnectedToServer
+    ''' <seealso cref="IChatBot.DisconnectedFromServer"/>
+    Public Event DisconnectedFromServer() Implements IChatBot.DisconnectedFromServer
+    ''' <seealso cref="IChatBot.JoinedChannel"/>
+    Public Event JoinedChannel(Channel As IChatBot.IChannel) Implements IChatBot.JoinedChannel
+    ''' <seealso cref="IChatBot.LeftChannel"/>
+    Public Event LeftChannel(Channel As IChatBot.IChannel) Implements IChatBot.LeftChannel
+    ''' <seealso cref="IChatBot.Ready"/>
+    Public Event Ready() Implements IChatBot.Ready
+    ''' <seealso cref="IChatBot.MessageReceived"/>
+    Public Event MessageReceived(Message As String, Source As IChatBot.IUser, Channel As IChatBot.IChannel) Implements IChatBot.MessageReceived
+    ''' <seealso cref="IChatBot.PrivateMessageReceived"/>
+    Public Event PrivateMessageReceived(Message As String, Source As IChatBot.IUser) Implements IChatBot.PrivateMessageReceived
+
+
+
+    ' Properties and fields
+
+    ''' <summary>
+    ''' The bot's username on Twitch.
+    ''' </summary>
+    Public ReadOnly Username As String
+
+    ''' <summary>
+    ''' The OAuth token used to authenticate the bot.
+    ''' </summary>
+    Private ReadOnly OAuthToken As String
+
+    ''' <summary>
+    ''' The Twitch channel that the 'bot listens and posts to.
+    ''' </summary>
+    Public ReadOnly BotChannel As Channel
+
+    ''' <summary>
+    ''' The Twitch channel that the 'bot listens and posts to.
+    ''' </summary>
+    Public ReadOnly Owner As User
+
+    ''' <summary>
+    ''' The Twitch API connection
+    ''' </summary>
+    Private WithEvents Client As TwitchClient
+
+    ''' <summary>
+    ''' True if the connection is currently closed.
+    ''' If this is True _when_ the OnDisconnect event fires,
+    ''' then do not try to reconnect.
+    ''' </summary>
+    Private ConnectionClosed As Boolean = True
+
+
+
+    ' Methods
+
+    ''' <summary>
+    ''' This creates a new TwitchBot instance and connects to the chat server.
+    ''' </summary>
+    ''' <param name="botUsername">The username to connect as.</param>
+    ''' <param name="botOAuth">The OAuth Token which will authenticate the bot.</param>
+    ''' <param name="channelName">The Twitch channel to connect to.</param>
+    ''' <param name="botOwner">The name of the user who owns the bot.</param>
+    Public Sub New(botUsername As String, botOAuth As String, channelName As String, botOwner As String)
+        ' Populate instance fields
+        Username = botUsername
+        OAuthToken = botOAuth
+        BotChannel = New Channel(channelName, Me)
+        Owner = New User(botOwner, Me)
+        Client = New TwitchClient()
+        ' Initialize the client
+        Dim credentials As New ConnectionCredentials(Username, OAuthToken)
+        Client.Initialize(credentials, BotChannel.ChannelName)
+        ' Connect to the API
+        Connect()
+    End Sub
+
+    ''' <summary>
+    ''' Connect to the chat server.  Raises a <see cref="IChatBot.ConnectionFailed"/> event with an error message if the connection fails.
+    ''' </summary>
+    Private Sub Connect()
+        Try
+            Client.Connect()
+        Catch ex As Exception
+            RaiseEvent ConnectionFailed(ex.Message)
+        End Try
+    End Sub
+
+    ''' <summary>
+    ''' Catches Twitch errors and reports them to the Debug stream.
+    ''' </summary>
+    ''' <param name="sender">The API object which raised the event.</param>
+    ''' <param name="e">The <code></code> which contains the exception that was caught.</param>
+    Private Sub Twitch_onError(sender As Object, e As OnErrorEventArgs) Handles Client.OnError
+        Debug.WriteLine(e.Exception.Message)
+    End Sub
+
+    ''' <summary>
+    ''' Handle the bot's initial connection to Twitch: Raise a <see cref="IChatBot.ConnectedToServer"/> event.
+    ''' </summary>
+    ''' <param name="sender">The API object which raised the event.</param>
+    ''' <param name="e">The <see cref="TwitchLib.Client.Events.OnConnectedArgs"/> which contains the <code>.BotUserName</code> that connected and the <code>.AutoJoinChannel</code> channel name that the bot automatically joined.</param>
+    Private Sub Twitch_OnConnected(ByVal sender As Object, ByVal e As OnConnectedArgs) Handles Client.OnConnected
+        Debug.WriteLine($"Connected to {e.AutoJoinChannel}")
+        ConnectionClosed = False
+        RaiseEvent ConnectedToServer()
+    End Sub
+
+    ''' <summary>
+    ''' Handle the bot reconnecting to Twitch: Raise a <see cref="IChatBot.ReconnectedToServer"/> event.
+    ''' </summary>
+    ''' <param name="sender">The API object which raised the event.</param>
+    ''' <param name="e">The <see cref="TwitchLib.Communication.Events.OnReconnectedEventArgs"/> which is empty.</param>
+    Private Sub Twitch_OnReconnected(ByVal sender As Object, ByVal e As OnReconnectedEventArgs) Handles Client.OnReconnected
+        RaiseEvent ReconnectedToServer()
+    End Sub
+
+    ''' <summary>
+    ''' Handle the bot disconnecting from Twitch: Raise a <see cref="IChatBot.DisconnectedFromServer"/> event and immediately try to connect again.
+    ''' </summary>
+    ''' <param name="sender">The API object which raised the event.</param>
+    ''' <param name="e">The <see cref="TwitchLib.Communication.Events.OnDisconnectedEventArgs"/> which is empty.</param>
+    Private Sub Twitch_OnDisconnected(ByVal sender As Object, ByVal e As OnDisconnectedEventArgs) Handles Client.OnDisconnected
+        Dim wasAlreadyClosed = ConnectionClosed
+        ConnectionClosed = True
+        RaiseEvent DisconnectedFromServer()
+        If Not wasAlreadyClosed Then
+            Connect()
+        End If
+    End Sub
+
+    ''' <summary>
+    ''' Handle the bot joining its channel: Raise a <see cref="IChatBot.JoinedChannel"/> event followed, if the channel was the bot's channel, by the <see cref="IChatBot.Ready"/> event.
+    ''' </summary>
+    ''' <param name="sender">The API object which raised the event.</param>
+    ''' <param name="e">The <see cref="TwitchLib.Client.Events.OnJoinedChannelArgs"/> which contains the <code>.BotUserName</code> that connected and the <code>.Channel</code> channel name that the bot joined.</param>
+    Private Sub Twitch_OnJoinedChannel(ByVal sender As Object, ByVal e As OnJoinedChannelArgs) Handles Client.OnJoinedChannel
+        RaiseEvent JoinedChannel(New Channel(e.Channel, Me))
+        If e.Channel = BotChannel.ChannelName Then
+            RaiseEvent Ready()
+        End If
+    End Sub
+
+    ''' <summary>
+    ''' Handle the bot leaving its channel: Raise a <see cref="IChatBot.LeftChannel"/> event.
+    ''' </summary>
+    ''' <param name="sender">The API object which raised the event.</param>
+    ''' <param name="e">The <code>OnLeftChannelArgs</code> which contains the <code>.BotUserName</code> that left the channel and the <code>.Channel</code> name that the bot left.</param>
+    Private Sub Twitch_onLeftChannel(sender As Object, e As OnLeftChannelArgs) Handles Client.OnLeftChannel
+        RaiseEvent LeftChannel(New Channel(e.Channel, Me))
+    End Sub
+
+    ''' <summary>
+    ''' Handle the bot receiving a message from the chat channel: Raise a corresponding <see cref="IChatBot.MessageReceived"/> event.
+    ''' </summary>
+    ''' <param name="sender">The API object which raised the event.</param>
+    ''' <param name="e">The <code>OnMessageReceivedArgs</code> which contains the <code>.ChatMessage</code> that was received.</param>
+    Private Sub Twitch_OnMessageReceived(ByVal sender As Object, ByVal e As OnMessageReceivedArgs) Handles Client.OnMessageReceived
+        RaiseEvent MessageReceived(e.ChatMessage.Message, New User(e.ChatMessage.Username, Me), New Channel(e.ChatMessage.Channel, Me))
+    End Sub
+
+    ''' <summary>
+    ''' Handle the bot receiving a message from the chat channel: Raise a corresponding <see cref="IChatBot.MessageReceived"/> event.
+    ''' </summary>
+    ''' <param name="sender">The API object which raised the event.</param>
+    ''' <param name="e">The <code>OnWhisperReceivedArgs</code> which contains the <code>.WhisperMessage</code> that was received.</param>
+    Private Sub Twitch_OnWhisperReceived(ByVal sender As Object, ByVal e As OnWhisperReceivedArgs) Handles Client.OnWhisperReceived
+        RaiseEvent PrivateMessageReceived(e.WhisperMessage.Message, New User(e.WhisperMessage.Username, Me))
+    End Sub
+
+    ''' <summary>
+    ''' Find a channel and return the <see cref="IChatBot.IChannel"/>
+    ''' representation of it.
+    ''' 
+    ''' THIS IS BROKEN and just creates a <code>ILingoChatBot.IChannel</code>
+    ''' instance with the channel name.  I have no idea if it would
+    ''' actually function.  (I don't even know if Twitch has the
+    ''' concept of multiple channels per room.)
+    ''' </summary>
+    ''' <param name="ChannelName">The name of the channel to find.</param>
+    ''' <returns>The <see cref="IChatBot.IChannel"/> corresponding to the named channel.</returns>
+    Public Function FindChannel(ChannelName As String) As IChatBot.IChannel Implements IChatBot.FindChannel
+        Return New Channel(ChannelName, Me)
+    End Function
+
+    ''' <summary>
+    ''' Find a user and return the <see cref="IChatBot.IUser"/>
+    ''' representation of it.
+    ''' 
+    ''' THIS IS BROKEN and just creates a <code>ILingoChatBot.IUser</code>
+    ''' instance with the user name.  I have no idea if it would
+    ''' actually function.
+    ''' </summary>
+    ''' <param name="UserName">The name of the user to find.</param>
+    ''' <returns>The <see cref="IChatBot.IUser"/> corresponding to the named user.</returns>
+    Public Function FindUser(UserName As String) As IChatBot.IUser Implements IChatBot.FindUser
+        Return New User(UserName, Me)
+    End Function
+
+    ''' <summary>
+    ''' Return the bot's owner.
+    ''' 
+    ''' NOTE - twitch does not seem to have registered bots, and so has no way of determining the bot's owner.
+    ''' This just returns the <code>Owner</code> user object that was created as part of this instance.
+    ''' </summary>
+    ''' <returns>The <code>Owner</code> of the bot.</returns>
+    Public Function BotOwner() As IChatBot.IUser Implements IChatBot.BotOwner
+        Return Owner
+    End Function
+
+    ''' <summary>
+    ''' Close the bot connection.
+    ''' </summary>
+    Public Sub Close() Implements IChatBot.Close
+        ' Signal we want the connection to stay closed
+        ConnectionClosed = True
+        Client.Disconnect()
+    End Sub
+
+    ''' <summary>
+    ''' Close and re-open the bot's connection.
+    ''' </summary>
+    Public Sub Reconnect() Implements IChatBot.Reconnect
+        If ConnectionClosed Then
+            Client.Connect()
+        Else
+            ' Disconnect and let the OnDisconnect handler re-connect
+            Client.Disconnect()
+        End If
+    End Sub
+End Class


### PR DESCRIPTION
This PR moves the Twitch connection logic into its own set of files that conforms to a new generic "IChatBot" interface that the main game logic uses.

Once again, it's probably easier to review commit-by-commit:
* The first commit adds the new `IChatBot` interface in `Lingo/IChatBot.vb` that provides a generic API by which the game logic can communicate with a chat bot implementation.  This is still very specific to this game :) but can be expanded if needed.  The `IChatBot` interface defines:
    - An `IChannel` interface that describes a channel that the chat bot can participate in.  Each channel has a name, some sort of ID, and a `SendMessage` method which can be used to send a message to that channel.
    - An `IUser` interface that describes a chat user that can communicate with the chat bot.  Like a channel, each user has a name, some sort of ID, and a `SendMessage` method which can be used to send a message to that user.  (Note - in Twitch, this may not be functional due to the API restrictions under which the bot operates)
    - A set of events that can be raised by the chat bot.  Not all events will be raised by all chat bots.
        * `ConnectionFailed(Reason As String)`
        * `ConnectedToServer`
        * `ReconnectedToServer`
        * `DisconnectedFromServer`
        * `JoinedChannel(Channel As IChannel)`
        * `LeftChannel(Channel As IChannel)`
        * `Ready`
        * `MessageReceived(Message As String, Channel As IChannel)`
        * `PrivateMessageReceived(Message As String, Source As IUser)`
    - And a set of public functions and subroutines that the chat bot must implement.
        * `FindChannel(ChannelName As String) As IChannel`
        * `FindUser(UserName As String) As IUser`
        * `BotOwner() As IUser`
        * `Close()`
        * `Reconnect()`

* The next commit just renames the `twitch_oauth` setting to `twitch_oauth_token` and adds a new `twitch_bot_owner` setting.

* The last commit moves the Twitch connection logic out of `Form1.vb` into a new class that implements the `IChatBot` interface, and reworks `Form1.vb` to use the `IChatBot` interface definitions.
    - In `Form1.vb`:
        * All the `TwitchLib` imports go away.
        * The `client` variable is replaced by `ChatBot` (including the `WithEvents` keyword to allow event handlers to be declared in the subroutine definitions)
        * A new `Channel` variable holds the bot's channel
        * The `gamemode` variable is now initialized to the (new) `GameModes.notready` value
        * The Twitch connection logic goes away.
        * The Twitch event handlers are removed and replaced with ChatBot event handlers (using the `Sub … Handles …` syntax):
            - The `ChatBot_Ready` event handler sends the `Lingo is Live!` message (but only if it has not done so before).  This event handler is invoked _after_ the channel has been joined.
            - The `ChatBot_ConnectedToServer`, `ChatBot_ReconnectedToServer`, and `ChatBot_DisconnectedFromServer` are the same as the previous similarly-named Twitch subroutines, except that `ChatBot_DisconnectedFromServer` does not have to include the automatic reconnect logic, as that's part of the Twitch logic itself
            - The `ChatBot_JoinedChannel` handler changes the connection status and sets the `Channel` variable if the currentl channel is unassigned.
            - The `ChatBot_MessageReceived` and `ChatBot_PrivateMessageReceived` handlers both invoke `Handle_ChatBot_Message()` (described below, reworked from `TwitchMessageReceived`)
            - The `ChatBot_LeftChannel` handler changes the connection status and unassigns the `Channel` variable if it matches the channel we just left.
            - The `ChatBot_ConnectionFailed` event handler is the same as the former `TwitchConnectionFailed` subroutine
        * The game logic is separated out from the UI logic:
            * `TwitchConnectionStatusChanged` is renamed to just `ConnectionStatusChanged`
            * `TwitchReceivedMessage` is renamed to `Handle_ChatBot_Message` with `fromUser` now referring to an `IUser` object; inner references to `fromUser` meaning the username are replaced with `fromUser.UserName`
            * `registerplayer` and `unregisterplayer` are refactored to just check if the player is (or is not) in the list of players and, if appropriate, add or remove the player from the player list and call a separate subrouting to add the player to or remove the player from the UI.
            * The player search logic in `updatescore` is simplified.
            * The player search logic in `sendfeedback` is simplified, and the way the message is sent is updated to call the `SendMessage` method of the appropriate `IUser` or `IChannel` object.
            * The player search logic in `lockinplayerguess` is simplified.
            * The player search logic in `updateplayerguess` is simplified and the UI management code is moved to a new `UpdatePlayerGuessInUI` subroutine.
            * The player search logic in `updateplayernotes` is simplified.
        * In the separated `UI Logic` section:
            * `Form1_Load` is moved here.
            * The new `AddPlayerToUI()`, `RemovePlayerFromUI()`, and `UpdatePlayerGuessInUI()` subroutines are added here.
            * **The `Button1_Click` subroutine is updated to not look at the client joined channel count, but just to assume that a message can be sent.**  _Not sure if this is the right thing to do_.
            * The `Button2_Click` and `Button3_Click` subroutines are updated to check if the channel is assigned and if not, to reconnect and wait before retrying.  Also, the generated message is now created via string interpolation (`$"…{expression}…"`) rather than joining different strings together.
            * The `GameTimer_Tick` subroutine is updated to check if the channel is assigned and use the channel to send the messages.

    - All the Twitch logic is moved to the new `TwitchBot.vb` class in a way that implements the `IChatBot` interface:
        * The `User` class implements `IChatBot.IUser`:
            - The user ID is the same as the user name.
            - The Twitch client is saved as a private member of the class.
            - The `SendMessage` method uses the client's `SendWhisper` subroutine.
        * The `Channel` class implements `IChatBot.IChannel`:
            - The channel ID is the same as the channel name.
            - The Twitch client is saved as a private member of the class.
            - The `SendMessage` method uses the client's `SendMessage` subroutine.
        * All the `IChatBot` events are implemented by this code.
        * When a `TwitchBot` object is created, it creates the client, authenticates, and connects.
        * Twitch event handlers mostly re-raise the `IChatBot` events.
            - The `OnDisconnect` Twitch event handler tries to reconnect _if_ the connection was intended to be open.
        * The `FindChannel` and `FindUser` functions of the `IChatBot` interface are implemented with "broken" functions that just create a channel or user that matches the passed-in name without verifying if they actually exist.  This could probably be improved, but the functionality is not used for this application.
        * The `Close()` method signals that the connection is intended to be closed before disconnecting, so that the `OnDisconnect` handler does not automatically reconnect.
        * The `Reconnect()` method checks if the connection is closed or not and calls `Connect()` if closed or `Disconnect` if open (to let the `OnDisconnect` handler perform the actual reconnect).
